### PR TITLE
Add a trivial Python example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 rendered
-
 **/.ipynb_checkpoints/
 **/volumes/
 **/shards/
@@ -8,12 +7,9 @@ rendered
 **/stderr
 bacalhau
 .vscode/
-
-# These files should sit within the related notebook in a cell with %%writefile
 **/Dockerfile
 **/.py
 **/requirements.txt
-
 .vscode
-
 js-helloworld/outputs/*
+.idea/

--- a/workload-onboarding/custom-containers/index.ipynb
+++ b/workload-onboarding/custom-containers/index.ipynb
@@ -6,7 +6,7 @@
             "source": [
                 "---\n",
                 "sidebar_label: \"Custom Containers\"\n",
-                "sidebar_position: 1\n",
+                "sidebar_position: 10\n",
                 "---"
             ]
         },

--- a/workload-onboarding/trivial-python/hello-world.py
+++ b/workload-onboarding/trivial-python/hello-world.py
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/workload-onboarding/trivial-python/index.ipynb
+++ b/workload-onboarding/trivial-python/index.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: \"Python Hello World\"\n",
+    "sidebar_position: 1\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Python Hello World\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bacalhau-project/examples/blob/main/workload-onboarding/trivial-python/index.ipynb)\n",
+    "[![Open In Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/bacalhau-project/examples/HEAD?labpath=workload-onboarding/trivial-python/index.ipynb)\n",
+    "\n",
+    "This example serves as an introduction to Bacalhau, running a Python file hosted on a website.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "Make sure you have the latest `bacalhau` client installed by following the [getting started instructions](../../../getting-started/installation) or using the installation command below (which installs Bacalhau local to the notebook)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: PATH=./:./:./:/Users/phil/.pyenv/versions/3.9.7/bin:/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/Users/phil/.gvm/bin:/opt/homebrew/opt/findutils/libexec/gnubin:/opt/homebrew/opt/coreutils/libexec/gnubin:/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/Users/phil/.pyenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/TeX/texbin:/usr/local/MacGPG2/bin:/Users/phil/.nexustools\n"
+     ]
+    }
+   ],
+   "source": [
+    "!command -v bacalhau >/dev/null 2>&1 || (export BACALHAU_INSTALL_DIR=.; curl -sL https://get.bacalhau.org/install.sh | bash)\n",
+    "path=!echo $PATH\n",
+    "%env PATH=./:{path[0]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hello, world\n",
+    "\n",
+    "For this example, we'll be using a very simple Python script which displays the [traditional first greeting](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "print(\"Hello, world!\")"
+     ]
+    }
+   ],
+   "source": [
+    "%cat hello-world.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Submit the workload\n",
+    "\n",
+    "To submit a workload to Bacalhau you can use the `bacalhau docker run` command. While you'll mainly be passing input data into the container using [content identifier (CID)](https://github.com/multiformats/cid) volumes, we will be using the `-u URL:path` argument for a simplicity. This results in Bacalhau mounting a *data volume* inside the container. By default, Bacalhau mounts the input volume at the path `/inputs` inside the container.\n",
+    "\n",
+    "Note that [Bacalhau overwrites the default entrypoint](https://github.com/filecoin-project/bacalhau/blob/v0.2.3/cmd/bacalhau/docker_run.go#L64), so we must run the full command after the `--` argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Job successfully submitted. Job ID: b65c5d6f-9695-40a5-9c53-b91b306cbeea\n",
+      "Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):\n",
+      "\n",
+      "\t       Creating job for submission ... done ✅\n",
+      "\t       Finding node(s) for the job ... done ✅\n",
+      "\t             Node accepted the job ... done ✅\n",
+      "\t                                   ... done ✅\n",
+      "\t   Job finished, verifying results ... done ✅\n",
+      "\t      Results accepted, publishing ... done ✅\n",
+      "\t                                  \n",
+      "Results CID: QmehTNF6ogbESt26EgrSw9YGrApneSWhPesqw1A5T6ezBe\n",
+      "Job Results By Node:\n",
+      "Node QmXaXu9N:\n",
+      "  Shard 0:\n",
+      "    Status: Cancelled\n",
+      "    No RunOutput for this shard\n",
+      "Node QmYgxZiy:\n",
+      "  Shard 0:\n",
+      "    Status: Completed\n",
+      "    Container Exit Code: 0\n",
+      "    Stdout:\n",
+      "      Hello, world!\n",
+      "    Stderr: <NONE>\n",
+      "Node QmdZQ7Zb:\n",
+      "  Shard 0:\n",
+      "    Status: Cancelled\n",
+      "    No RunOutput for this shard\n",
+      "\n",
+      "To download the results, execute:\n",
+      "  bacalhau get b65c5d6f-9695-40a5-9c53-b91b306cbeea\n",
+      "\n",
+      "To get more details about the run, execute:\n",
+      "  bacalhau describe b65c5d6f-9695-40a5-9c53-b91b306cbeea\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "bacalhau docker run \\\n",
+    "  --input-urls https://raw.githubusercontent.com/bacalhau-project/examples/trivial-python-example/workload-onboarding/trivial-python/hello-world.py \\\n",
+    "  python:3.10-slim -- python3 /inputs/hello-world.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Results\n",
+    "\n",
+    "If you look at the `stdout` from the previous command you'll see that it successfully ran the python file."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.7 64-bit ('3.9.7')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "21fd917facdca5c02b7d24e32528f1b4e6711465b0262edbfffba943391e1222"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Add an example of running a trivial Python program, as a simple introduction to running bacalhau.

Also adds JetBrains IDE directories to gitignore

Fixes #742