### PR TITLE
feat: allow class weights and confidence to be set via envvar

### DIFF
--- a/model-inference/object-detection-yolo5/Dockerfile
+++ b/model-inference/object-detection-yolo5/Dockerfile
@@ -1,7 +1,14 @@
 # v7.0
+# example: docker run -e CLASSES="1 2 3" -e CONF_THRES="0.5"
 FROM ultralytics/yolov5@sha256:e21b0e965dedac95aac3c6d6d38e2ee26695e1a0cef79d0b746b3fa9bae4f7c6
 
+# Embed a default model that we may override via env var
 RUN mkdir /model
 ADD https://github.com/ultralytics/yolov5/releases/download/v7.0/yolov5s.pt /model
 
-ENTRYPOINT [ "python", "detect.py", "--weights","/model/yolov5s.pt", "--source","/videos","--project","/outputs","--class","1","2","3","4","5","6","7","9","10","11","12","--save-crop","--conf-thres=.7" ]
+# Set default environment variables
+ENV CLASSES="1 2 3 4 5 6 7 9 10 11 12"
+ENV CONF_THRES="0.7"
+ENV WEIGHTS_PATH="/model/yolov5s.pt"
+
+ENTRYPOINT ["sh", "-c", "python detect.py --weights $WEIGHTS_PATH --source /videos --project /outputs --class $CLASSES --save-crop --conf-thres=$CONF_THRES"]


### PR DESCRIPTION
allow weights, classes and confidence to be passed via env var, using defaults when none are provided. For example:
```bash 
$ bacalhau docker run \
 --input file:///home/frrist/Videos \
--input https://github.com/ultralytics/yolov5/releases/download/v6.2/yolov5x.pt:/model \
forrestexpanso/forrest-yolov5 --env=WEIGHTS_PATH=/model/yolov5x.pt --env=CLASSES=0
```
will download the mode and use it via an env var where:
```bash
$ bacalhau docker run --target=all \
--input file:///video_dir:/videos \
docker.io/bacalhauproject/yolov5-7.0:v1.0
```
will use the defaults of the container
