### PR TITLE
fix(csv-to-avro): Remove redundant unicode type mapping causing errors

### DIFF
--- a/data-engineering/csv-to-avro-or-parquet/csv-to-avro-parquet/src/converter.py
+++ b/data-engineering/csv-to-avro-or-parquet/csv-to-avro-parquet/src/converter.py
@@ -110,7 +110,6 @@ class AvroConverter(BaseConverter):
         np.dtype('int64'): 'long',
         np.dtype('uint64'): 'long',
         np.dtype('O'): ['null', 'string', 'float'],
-        np.dtype('unicode_'): 'string',
         np.dtype('float32'): 'float',
         np.dtype('float64'): 'double',
         np.dtype('datetime64'): {


### PR DESCRIPTION
Fixed a bug where the converter was failing on string data. Here's what I did:

• Removed a problematic unicode type mapping that was throwing errors
• Kept the existing object dtype ('O') mapping which already handles strings correctly
• Double-checked that CSV files with text columns still work as expected

For context: Pandas already handles string columns just fine using its default object type, 
so we didn't need the extra unicode mapping that was causing problems.

Fixes the error: "TypeError: data type unicode_ not understood"