### PR TITLE
improve docker compose setup

### DIFF
--- a/setting-up-bacalhau-cluster/docker-compose/README.md
+++ b/setting-up-bacalhau-cluster/docker-compose/README.md
@@ -25,7 +25,7 @@ The single-region configuration provides a simple Bacalhau cluster with:
 
 - 1 orchestrator node
 - 10 compute nodes
-- MinIO object storage
+- Storage object storage
 - A client container for interacting with the cluster
 
 ### Usage
@@ -39,13 +39,13 @@ docker compose up -d
 
 - **Orchestrator**: Manages job scheduling and cluster coordination
 - **Compute Nodes**: Execute jobs (10 replicas)
-- **MinIO**: S3-compatible object storage for job results
+- **Storage**: S3-compatible object storage for job results (MinIO)
 - **Client**: Interactive container for submitting jobs
 
 ### Ports
 
 - Orchestrator: 8438 (API), 1234 (API), 4222 (NATS)
-- MinIO: 9000 (API), 9001 (Console)
+- Storage: 9000 (API), 9001 (Console)
 
 ## Multi-Region Setup
 
@@ -54,7 +54,7 @@ The multi-region configuration simulates a geographically distributed cluster wi
 - 1 global orchestrator
 - 3 compute nodes in US region
 - 3 compute nodes in EU region
-- 3 MinIO instances (global, US region, EU region)
+- 3 Storage instances (global, US region, EU region)
 - A client container for interacting with the cluster
 
 ### Usage
@@ -70,7 +70,7 @@ docker compose up -d
 - **Compute Nodes**:
   - US Region: 3 nodes (compute-us-1, compute-us-2, compute-us-3)
   - EU Region: 3 nodes (compute-eu-1, compute-eu-2, compute-eu-3)
-- **MinIO Instances**:
+- **Storage Instances**:
   - Global: Used by orchestrator for job results (Port 9000/9001)
   - US Region: Used by US compute nodes (Port 9002/9003)
   - EU Region: Used by EU compute nodes (Port 9004/9005)
@@ -85,9 +85,9 @@ docker compose up -d
 ### Ports
 
 - Orchestrator: 8438 (API), 1234 (API), 4222 (NATS)
-- MinIO Global: 9000 (API), 9001 (Console)
-- MinIO US: 9002 (API), 9003 (Console)
-- MinIO EU: 9004 (API), 9005 (Console)
+- Storage Global: 9000 (API), 9001 (Console)
+- Storage US: 9002 (API), 9003 (Console)
+- Storage EU: 9004 (API), 9005 (Console)
 
 ## Common Configuration
 
@@ -117,8 +117,16 @@ bacalhau job run ...
 
 ## Cleanup
 
-To stop and remove the cluster:
+To stop and remove the cluster, including all volumes and orphaned containers:
 
 ```bash
-docker compose down -v
+docker compose down -v --remove-orphans
 ```
+
+This will:
+
+- Stop all containers
+- Remove all containers
+- Remove all volumes 
+- Remove any orphaned containers
+- Remove all networks

--- a/setting-up-bacalhau-cluster/docker-compose/multi-region/config/compute-eu.yaml
+++ b/setting-up-bacalhau-cluster/docker-compose/multi-region/config/compute-eu.yaml
@@ -1,9 +1,2 @@
-NameProvider: hostname
-Compute:
-  Enabled: true
-  Orchestrators:
-    - orchestrator:4222
 Labels:
   region: eu
-UpdateConfig:
-  Interval: 0 

--- a/setting-up-bacalhau-cluster/docker-compose/multi-region/config/compute-us.yaml
+++ b/setting-up-bacalhau-cluster/docker-compose/multi-region/config/compute-us.yaml
@@ -1,9 +1,2 @@
-NameProvider: hostname
-Compute:
-  Enabled: true
-  Orchestrators:
-    - orchestrator:4222
 Labels:
   region: us
-UpdateConfig:
-  Interval: 0 

--- a/setting-up-bacalhau-cluster/docker-compose/multi-region/config/compute.yaml
+++ b/setting-up-bacalhau-cluster/docker-compose/multi-region/config/compute.yaml
@@ -1,0 +1,12 @@
+NameProvider: hostname
+Compute:
+  Enabled: true
+  Orchestrators:
+    - orchestrator:4222
+  Env:
+    AllowList:
+      - AWS_*
+UpdateConfig:
+  Interval: 0
+JobAdmissionControl:
+  AcceptNetworkedJobs: true

--- a/setting-up-bacalhau-cluster/docker-compose/multi-region/config/orchestrator.yaml
+++ b/setting-up-bacalhau-cluster/docker-compose/multi-region/config/orchestrator.yaml
@@ -15,8 +15,8 @@ JobDefaults:
         Params:
           Bucket: "my-bucket"
           Key: jobs/{jobID}/{executionID}
-          Endpoint: "http://minio:9000"
-          Region: "minio-region"
+          Endpoint: "http://storage:9000"
+          Region: "storage-region"
   Ops:
     Task:
       Publisher:
@@ -24,5 +24,5 @@ JobDefaults:
         Params:
           Bucket: "my-bucket"
           Key: jobs/{jobID}/{executionID}
-          Endpoint: "http://minio:9000"
-          Region: "minio-region"
+          Endpoint: "http://storage:9000"
+          Region: "storage-region"

--- a/setting-up-bacalhau-cluster/docker-compose/multi-region/docker-compose.yml
+++ b/setting-up-bacalhau-cluster/docker-compose/multi-region/docker-compose.yml
@@ -7,9 +7,15 @@ x-common-env-variables: &common-env-variables
   AWS_SECRET_ACCESS_KEY: "minioadmin"
   BACALHAU_DISABLEANALYTICS: true
 
+x-orchestrator-image: &orchestrator-image
+  image: ghcr.io/bacalhau-project/bacalhau:${ORCHESTRATOR_IMAGE_TAG:-latest}
+
+x-compute-image: &compute-image
+  image: ghcr.io/bacalhau-project/bacalhau:${COMPUTE_IMAGE_TAG:-latest-dind}
+
 services:
   orchestrator:
-    image: ghcr.io/bacalhau-project/bacalhau:latest
+    <<: *orchestrator-image
     hostname: orchestrator
     command: serve -c /etc/bacalhau/config.yaml --name orchestrator
     environment: *common-env-variables
@@ -29,22 +35,23 @@ services:
       start_period: 5s
 
   compute-us-1:
-    image: ghcr.io/bacalhau-project/bacalhau:latest-dind
+    <<: *compute-image
     hostname: compute-us-1
-    command: serve -c /etc/bacalhau/config.yaml
+    command: serve -c /etc/bacalhau/config.yaml  -c /etc/bacalhau/config-regional.yaml
+    volumes:
+      - ./config/compute.yaml:/etc/bacalhau/config.yaml
+      - ./config/compute-us.yaml:/etc/bacalhau/config-regional.yaml
     environment:
       <<: *common-env-variables
     depends_on:
       orchestrator:
         condition: service_healthy
-      minio-us:
+      storage-us:
         condition: service_healthy
     privileged: true
     networks:
       - bacalhau-network
       - us-region
-    volumes:
-      - ./config/compute-us.yaml:/etc/bacalhau/config.yaml
 
   compute-us-2:
     extends: compute-us-1
@@ -54,7 +61,7 @@ services:
     extends: compute-us-1
     hostname: compute-us-3
 
-  minio-us:
+  storage-us:
     image: quay.io/minio/minio
     entrypoint: sh
     command: -c 'mkdir -p /data/my-bucket && minio server /data --console-address ":9001"'
@@ -65,7 +72,7 @@ services:
     networks:
       us-region:
         aliases:
-          - minio-local
+          - storage-local
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 2s
@@ -74,22 +81,23 @@ services:
       start_period: 5s
 
   compute-eu-1:
-    image: ghcr.io/bacalhau-project/bacalhau:latest-dind
+    <<: *compute-image
     hostname: compute-eu-1
-    command: serve -c /etc/bacalhau/config.yaml
+    command: serve -c /etc/bacalhau/config.yaml  -c /etc/bacalhau/config-regional.yaml
+    volumes:
+      - ./config/compute.yaml:/etc/bacalhau/config.yaml
+      - ./config/compute-eu.yaml:/etc/bacalhau/config-regional.yaml
     environment:
       <<: *common-env-variables
     depends_on:
       orchestrator:
         condition: service_healthy
-      minio-eu:
+      storage-eu:
         condition: service_healthy
     privileged: true
     networks:
       - bacalhau-network
       - eu-region
-    volumes:
-      - ./config/compute-eu.yaml:/etc/bacalhau/config.yaml
 
   compute-eu-2:
     extends: compute-eu-1
@@ -99,7 +107,7 @@ services:
     extends: compute-eu-1
     hostname: compute-eu-3
 
-  minio-eu:
+  storage-eu:
     image: quay.io/minio/minio
     entrypoint: sh
     command: -c 'mkdir -p /data/my-bucket && minio server /data --console-address ":9001"'
@@ -110,7 +118,7 @@ services:
     networks:
       eu-region:
         aliases:
-          - minio-local
+          - storage-local
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 2s
@@ -133,7 +141,7 @@ services:
     networks:
       - bacalhau-network
 
-  minio-global:
+  storage-global:
     image: quay.io/minio/minio
     entrypoint: sh
     command: -c 'mkdir -p /data/my-bucket && minio server /data --console-address ":9001"'
@@ -144,7 +152,7 @@ services:
     networks:
       bacalhau-network:
         aliases:
-          - minio
+          - storage
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 2s

--- a/setting-up-bacalhau-cluster/docker-compose/single-region/config/orchestrator.yaml
+++ b/setting-up-bacalhau-cluster/docker-compose/single-region/config/orchestrator.yaml
@@ -12,8 +12,8 @@ JobDefaults:
         Params:
           Bucket: "my-bucket"
           Key: jobs/{jobID}/{executionID}
-          Endpoint: "http://minio:9000"
-          Region: "minio-region"
+          Endpoint: "http://storage:9000"
+          Region: "storage-region"
   Ops:
     Task:
       Publisher:
@@ -21,5 +21,5 @@ JobDefaults:
         Params:
           Bucket: "my-bucket"
           Key: jobs/{jobID}/{executionID}
-          Endpoint: "http://minio:9000"
-          Region: "minio-region"
+          Endpoint: "http://storage:9000"
+          Region: "storage-region"

--- a/setting-up-bacalhau-cluster/docker-compose/single-region/docker-compose.yml
+++ b/setting-up-bacalhau-cluster/docker-compose/single-region/docker-compose.yml
@@ -7,9 +7,15 @@ x-common-env-variables: &common-env-variables
   AWS_SECRET_ACCESS_KEY: "minioadmin"
   BACALHAU_DISABLEANALYTICS: true
 
+x-orchestrator-image: &orchestrator-image
+  image: ghcr.io/bacalhau-project/bacalhau:${ORCHESTRATOR_IMAGE_TAG:-latest}
+
+x-compute-image: &compute-image
+  image: ghcr.io/bacalhau-project/bacalhau:${COMPUTE_IMAGE_TAG:-latest-dind}
+
 services:
   orchestrator:
-    image: ghcr.io/bacalhau-project/bacalhau:latest
+    <<: *orchestrator-image
     hostname: orchestrator
     command: serve -c /etc/bacalhau/config.yaml --name orchestrator
     environment: *common-env-variables
@@ -29,24 +35,24 @@ services:
       start_period: 5s
 
   compute:
-    image: ghcr.io/bacalhau-project/bacalhau:latest-dind
+    <<: *compute-image
     command: serve -c /etc/bacalhau/config.yaml
+    volumes:
+      - ./config/compute.yaml:/etc/bacalhau/config.yaml
     environment:
       <<: *common-env-variables
     depends_on:
       orchestrator:
         condition: service_healthy
-      minio:
+      storage:
         condition: service_healthy
     deploy:
       replicas: 10
     privileged: true
     networks:
       - bacalhau-network
-    volumes:
-      - ./config/compute.yaml:/etc/bacalhau/config.yaml
 
-  minio:
+  storage:
     image: quay.io/minio/minio
     entrypoint: sh
     command: -c 'mkdir -p /data/my-bucket && minio server /data --console-address ":9001"'
@@ -56,8 +62,6 @@ services:
       - "9001:9001"
     networks:
       bacalhau-network:
-        aliases:
-          - minio-local
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 2s


### PR DESCRIPTION
- Allow overriding image tags for local testing purposes
- Rename minio instances to storage for more decoupling of storage implementation
- Pass throw AWS* env variables to jobs
- Use multiple config files 